### PR TITLE
Add dependency tracking for sector2.asm changes

### DIFF
--- a/src/boot/CMakeLists.txt
+++ b/src/boot/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(boot boot.asm)
 add_custom_command(
     OUTPUT ${BOOT_OUTPUT_DIR}/sector2.o
     COMMAND nasm -f elf32 ${CMAKE_CURRENT_SOURCE_DIR}/sector2.asm -o ${BOOT_OUTPUT_DIR}/sector2.o
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/sector2.asm
 )
 set(NULL_CPP_FILE_PATH "${CMAKE_BINARY_DIR}/_yros_cmake_hack/null.cpp")
 file(WRITE ${NULL_CPP_FILE_PATH} "")


### PR DESCRIPTION
Problem:
- make failed to rebuild sector2.o when sector2.asm was modified

Reason:
- Missing explicit dependency declaration for assembly source in CMakeLists.txt

Solution:
- Added DEPENDS clause pointing to sector2.asm in add_custom_command
- Ensures build system detects changes to assembly files and triggers recompilation